### PR TITLE
Korrektur JB-Spielwaren

### DIFF
--- a/brickmerge.js
+++ b/brickmerge.js
@@ -2,7 +2,7 @@
 // @name           brickmerge® Prices
 // @name:de        brickmerge® Preise
 // @namespace      https://brickmerge.de/
-// @version        1.9
+// @version        1.91
 // @license        MIT
 // @description    Displays lowest brickmerge® price next to offer price
 // @description:de Zeigt den bisherigen Bestpreis von brickmerge® parallel zum aktuellen Preis an
@@ -47,7 +47,7 @@
       },
       "www.jb-spielwaren.de": {
           articleSelector: "h1",
-          targetSelector: ".crossprice",
+          targetSelector: ".widget-availability",
           testURL: "https://www.jb-spielwaren.de/lego-10293-besuch-des-weihnachtsmanns/a-10293/",
       },
       "steinehelden.de": {

--- a/brickmerge.js
+++ b/brickmerge.js
@@ -2,7 +2,7 @@
 // @name           brickmerge® Prices
 // @name:de        brickmerge® Preise
 // @namespace      https://brickmerge.de/
-// @version        1.10
+// @version        1.11
 // @license        MIT
 // @description    Displays lowest brickmerge® price next to offer price
 // @description:de Zeigt den bisherigen Bestpreis von brickmerge® parallel zum aktuellen Preis an

--- a/brickmerge.js
+++ b/brickmerge.js
@@ -2,7 +2,7 @@
 // @name           brickmerge® Prices
 // @name:de        brickmerge® Preise
 // @namespace      https://brickmerge.de/
-// @version        1.91
+// @version        1.10
 // @license        MIT
 // @description    Displays lowest brickmerge® price next to offer price
 // @description:de Zeigt den bisherigen Bestpreis von brickmerge® parallel zum aktuellen Preis an


### PR DESCRIPTION
JB-Spielwaren:

.crossprice funktioniert nur, wenn der angezeigte Artikel auch einen vergünstigten Streichpreis hat. Mit dieser Änderung rutscht die Anzeige eine Etage tiefer und kann somit immer angezeigt werden - unabhängig ob ein Streichpreis vorhanden ist oder nicht.